### PR TITLE
Install and use rinf in rust-clippy workflow

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -44,20 +44,11 @@ jobs:
       - name: Install rinf
         run: cargo install rinf
 
-      - name: Navigate two directories above
-        run: |
-          cd ..
-          cd ..
-        working-directory: ${{ github.workspace }}
-
-      - name: Run rinf message
-        run: rinf message
-
-      - name: Return to original working directory
-        run: cd ${{ github.workspace }}
-        
       - name: Run rust-clippy
-        run:
+        run: |
+          cd ../.. && \ # Navigate two directories above
+          rinf message && \ # Generate the messages
+          cd ${{ github.workspace }} && \
           cargo clippy
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -44,8 +44,14 @@ jobs:
       - name: Install rinf
         run: cargo install rinf
 
+      - name: Change directory
+        run: cd ../../
+
       - name: Run rinf message
         run: rinf message
+
+      - name: Change back the directory
+        run: cd -
         
       - name: Run rust-clippy
         run:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -49,8 +49,8 @@ jobs:
           cd ../.. # Navigate two directories above
           rinf message # Generate the messages
           cd ${{ github.workspace }}
-          | cargo clippy
-          --all-features
+          cargo clippy \
+          --all-features \
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
 
+      - name: Install rinf
+        run: cargo install rinf
+
+      - name: Run rinf message
+        run: rinf message
+        
       - name: Run rust-clippy
         run:
           cargo clippy

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Run rust-clippy
         run: |
-          cd ../.. && \ # Navigate two directories above
-          rinf message && \ # Generate the messages
-          cd ${{ github.workspace }} && \
-          cargo clippy
+          cd ../.. # Navigate two directories above
+          rinf message # Generate the messages
+          cd ${{ github.workspace }}
+          | cargo clippy
           --all-features
           --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -44,14 +44,17 @@ jobs:
       - name: Install rinf
         run: cargo install rinf
 
-      - name: Change directory
-        run: cd ../../
+      - name: Navigate two directories above
+        run: |
+          cd ..
+          cd ..
+        working-directory: ${{ github.workspace }}
 
       - name: Run rinf message
         run: rinf message
 
-      - name: Change back the directory
-        run: cd -
+      - name: Return to original working directory
+        run: cd ${{ github.workspace }}
         
       - name: Run rust-clippy
         run:


### PR DESCRIPTION
Without running `rinf message` on the code, the desired message will not be generated which is needed for proper compilation of rust code